### PR TITLE
feat: 전역에러처리 도입

### DIFF
--- a/src/main/java/com/example/stormpaws/infra/security/SecurityConfig.java
+++ b/src/main/java/com/example/stormpaws/infra/security/SecurityConfig.java
@@ -41,8 +41,7 @@ public class SecurityConfig {
     http.csrf(csrf -> csrf.disable())
         .sessionManagement(
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-        .authorizeHttpRequests(
-            authz -> authz.requestMatchers("/public/**").permitAll().anyRequest().authenticated())
+        .authorizeHttpRequests(auth -> auth.requestMatchers("/**").permitAll())
         .addFilterBefore(
             new JwtAuthenticationFilter(jwtTokenProvider, customUserDetailsService),
             UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/example/stormpaws/service/UserService.java
+++ b/src/main/java/com/example/stormpaws/service/UserService.java
@@ -27,6 +27,13 @@ public class UserService {
     this.tokenProvider = tokenProvider;
   }
 
+  /**
+   * @param authServer OAuth 제공자 이름 (예: "google", "kakao")
+   * @param code OAuth 인증 코드 (인가 코드)
+   * @return accessToken과 refreshToken이 포함된 AuthDataDTO
+   * @throws com.example.stormpaws.service.oauth.OAuthException - 인증 서버로부터 토큰 발급 실패 시 - 사용자 정보 조회 실패
+   *     시
+   */
   public AuthDataDTO login(String authServer, String code) {
     IOAuthProvider provider = oauthProviderFactory.getProvider(authServer);
     String providerAccessToken = provider.getOAuthToken(code);

--- a/src/main/java/com/example/stormpaws/service/exception/OAuthException.java
+++ b/src/main/java/com/example/stormpaws/service/exception/OAuthException.java
@@ -1,0 +1,12 @@
+package com.example.stormpaws.service.exception;
+
+public class OAuthException extends RuntimeException {
+
+  public OAuthException(String message) {
+    super(message);
+  }
+
+  public OAuthException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/com/example/stormpaws/web/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/stormpaws/web/exception/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.example.stormpaws.web.exception;
+
+import com.example.stormpaws.service.exception.OAuthException;
+import com.example.stormpaws.web.dto.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(OAuthException.class)
+  public ResponseEntity<ApiResponse<?>> handleOAuthException(OAuthException ex) {
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED) // 401
+        .body(new ApiResponse<>(false, ex.getMessage(), null));
+  }
+
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<ApiResponse<?>> handleIllegalArgument(IllegalArgumentException ex) {
+    return ResponseEntity.badRequest() // 400
+        .body(new ApiResponse<>(false, ex.getMessage(), null));
+  }
+}

--- a/util/rest_client/user/GET user login.http
+++ b/util/rest_client/user/GET user login.http
@@ -1,6 +1,2 @@
-POST {{stormpaw-host}}/user/login/google
+GET {{stormpaw-host}}/user/login/google?code=123
 Content-Type: application/json
-Authorization: Bearer {{stormpaw-jwt}}
-{
-    "code": "123123"
-}


### PR DESCRIPTION
### 변경사항:

- spring security 단에서 권한 체크하는거 풀고, controller단에서 체크하도록 바꿨습니다.

### 추가사항: 

- Oauth 커스텀 익셉션 추가
- 에러 throw시 전역 캐치후 http response 래핑하는 전역에러핸들러 추가

### 고려사항:

#### 전역에러 핸들러 및 커스텀 에러 관련

- 왠만하면 service 단에서 runtime 커스텀에러를 만드시고(안만들수있으면 안만들어도됩니다), Service 함수에서 catch하지말고 흘리세요. 단 param에 적어주면 개발하기 편합니다.
- 컨트롤러단에서 직접 에러 캐치 해도 되지만, 저는 전역 매퍼에서 관리하도록 설계해놨어요. 이를 참고하셔서 구현하시면 좋을듯합니다.