### PR TITLE
Feat/deck/randomfetch

### DIFF
--- a/src/main/java/com/example/stormpaws/domain/IRepository/IDeckRepository.java
+++ b/src/main/java/com/example/stormpaws/domain/IRepository/IDeckRepository.java
@@ -14,4 +14,6 @@ public interface IDeckRepository {
 
   // 덱을 저장하는 메소드
   DeckModel save(DeckModel deckModel);
+
+  List<String> findAllUserIdsWithDecks();
 }

--- a/src/main/java/com/example/stormpaws/domain/IRepository/IUserRepository.java
+++ b/src/main/java/com/example/stormpaws/domain/IRepository/IUserRepository.java
@@ -1,6 +1,7 @@
 package com.example.stormpaws.domain.IRepository;
 
 import com.example.stormpaws.domain.model.UserModel;
+import java.util.List;
 import java.util.Optional;
 
 public interface IUserRepository {
@@ -11,4 +12,6 @@ public interface IUserRepository {
   Optional<UserModel> findByEmail(String email);
 
   Optional<UserModel> findById(String id);
+
+  List<String> findAllUserId();
 }

--- a/src/main/java/com/example/stormpaws/infra/jpa/DeckRepository.java
+++ b/src/main/java/com/example/stormpaws/infra/jpa/DeckRepository.java
@@ -33,4 +33,7 @@ public interface DeckRepository extends JpaRepository<DeckModel, String>, IDeckR
         WHERE d.user.id = :userId
         """)
   List<DeckModel> findByUserIdWithDeckCardsAndCards(@Param("userId") String userId);
+
+  @Query("SELECT DISTINCT d.user.id FROM DeckModel d")
+  List<String> findAllUserIdsWithDecks();
 }

--- a/src/main/java/com/example/stormpaws/infra/jpa/UserRepository.java
+++ b/src/main/java/com/example/stormpaws/infra/jpa/UserRepository.java
@@ -2,8 +2,16 @@ package com.example.stormpaws.infra.jpa;
 
 import com.example.stormpaws.domain.IRepository.IUserRepository;
 import com.example.stormpaws.domain.model.UserModel;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface UserRepository extends JpaRepository<UserModel, String>, IUserRepository {}
+public interface UserRepository extends JpaRepository<UserModel, String>, IUserRepository {
+  // TODO : querydsl로 변경하기
+
+  @Override
+  @Query("SELECT u.id FROM UserModel u")
+  List<String> findAllUserId();
+}

--- a/src/main/java/com/example/stormpaws/service/DeckService.java
+++ b/src/main/java/com/example/stormpaws/service/DeckService.java
@@ -93,7 +93,8 @@ public class DeckService {
     return deckModel;
   }
 
-  // public List<DeckModel> getRandomDeckList(int size) {
+  // public List<DeckModel> getRandomDecks(int count, UserModel user) {
+
   // }
 
   @Transactional

--- a/src/main/java/com/example/stormpaws/web/controller/DeckController.java
+++ b/src/main/java/com/example/stormpaws/web/controller/DeckController.java
@@ -6,6 +6,7 @@ import com.example.stormpaws.service.DeckService;
 import com.example.stormpaws.service.dto.DeckCardDTO;
 import com.example.stormpaws.service.dto.PagedResultDTO;
 import com.example.stormpaws.web.dto.request.CreateDeckBody;
+import com.example.stormpaws.web.dto.request.RandomDeckQueryParam;
 import com.example.stormpaws.web.dto.response.ApiResponse;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -14,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -61,16 +63,16 @@ public class DeckController {
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
-  // @GetMapping("/decks/random")
-  // public ResponseEntity<ApiResponse<List<DeckModel>>> getRandomDecks(
-  //     @Valid @ModelAttribute RandomDeckQueryParam  count,
-  //     @AuthenticationPrincipal CustomUserDetails userDetails
-  //   ) {
-
-  //   List<DeckModel> result = deckService.getRandomDecks(count, userDetails.getUser());
-  //   ApiResponse<List<DeckModel>> response = new ApiResponse<>(true, "success", result);
-  //   return ResponseEntity.ok(response);
-  // }
+  // TODO 전역 advice로 처리히기
+  @GetMapping("/decks/random")
+  public ResponseEntity<ApiResponse<PagedResultDTO<DeckModel>>> getRandomDecks(
+      @Valid @ModelAttribute RandomDeckQueryParam param,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    int count = param.resolvedCount();
+    PagedResultDTO<DeckModel> result = deckService.getRandomDecks(count, userDetails.getUser());
+    ApiResponse<PagedResultDTO<DeckModel>> response = new ApiResponse<>(true, "success", result);
+    return ResponseEntity.ok(response);
+  }
 
   private DeckCardDTO mapToDeckCardDTO(CreateDeckBody requestDTO) {
     List<DeckCardDTO.CardDTO> cardDTOList =

--- a/src/main/java/com/example/stormpaws/web/controller/DeckController.java
+++ b/src/main/java/com/example/stormpaws/web/controller/DeckController.java
@@ -5,7 +5,7 @@ import com.example.stormpaws.infra.security.CustomUserDetails;
 import com.example.stormpaws.service.DeckService;
 import com.example.stormpaws.service.dto.DeckCardDTO;
 import com.example.stormpaws.service.dto.PagedResultDTO;
-import com.example.stormpaws.web.dto.request.DeckCreateRequest;
+import com.example.stormpaws.web.dto.request.CreateDeckBody;
 import com.example.stormpaws.web.dto.response.ApiResponse;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -32,24 +32,26 @@ public class DeckController {
   }
 
   @GetMapping("/decks/{deckId}")
-  public ResponseEntity<DeckModel> getDeckByID(@PathVariable String deckId) {
+  public ResponseEntity<ApiResponse<DeckModel>> getDeckByID(@PathVariable String deckId) {
     DeckModel deck = deckService.getDeckById(deckId);
-    return ResponseEntity.ok(deck);
+    ApiResponse<DeckModel> response = new ApiResponse<>(true, "success", deck);
+    return ResponseEntity.ok(response);
   }
 
   @GetMapping("/user/me/decks")
-  public ResponseEntity<PagedResultDTO<DeckModel>> getMyDecks(
+  public ResponseEntity<ApiResponse<PagedResultDTO<DeckModel>>> getMyDecks(
       @AuthenticationPrincipal CustomUserDetails userDetails,
-      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "1") int page,
       @RequestParam(defaultValue = "10") int size) {
     String userId = userDetails.getUser().getId();
     PagedResultDTO<DeckModel> result = deckService.getMyDeckList(userId, page, size);
-    return ResponseEntity.ok(result);
+    ApiResponse<PagedResultDTO<DeckModel>> response = new ApiResponse<>(true, "success", result);
+    return ResponseEntity.ok(response);
   }
 
   @PostMapping("/user/me/decks")
   public ResponseEntity<ApiResponse<DeckModel>> createDeck(
-      @Valid @RequestBody DeckCreateRequest requestDTO,
+      @Valid @RequestBody CreateDeckBody requestDTO,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
     DeckCardDTO deckCardDTO = mapToDeckCardDTO(requestDTO);
     DeckModel deckModel = deckService.createDeck(deckCardDTO, userDetails.getUser());
@@ -59,10 +61,18 @@ public class DeckController {
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
-  // @GetMapping("/decks/random-opponents")
-  // public ResponseEntity<?> getRandomDeck() {}
+  // @GetMapping("/decks/random")
+  // public ResponseEntity<ApiResponse<List<DeckModel>>> getRandomDecks(
+  //     @Valid @ModelAttribute RandomDeckQueryParam  count,
+  //     @AuthenticationPrincipal CustomUserDetails userDetails
+  //   ) {
 
-  private DeckCardDTO mapToDeckCardDTO(DeckCreateRequest requestDTO) {
+  //   List<DeckModel> result = deckService.getRandomDecks(count, userDetails.getUser());
+  //   ApiResponse<List<DeckModel>> response = new ApiResponse<>(true, "success", result);
+  //   return ResponseEntity.ok(response);
+  // }
+
+  private DeckCardDTO mapToDeckCardDTO(CreateDeckBody requestDTO) {
     List<DeckCardDTO.CardDTO> cardDTOList =
         requestDTO.cards().stream()
             .map(card -> new DeckCardDTO.CardDTO(card.cardId(), card.quantity(), card.pos()))

--- a/src/main/java/com/example/stormpaws/web/dto/request/CreateDeckBody.java
+++ b/src/main/java/com/example/stormpaws/web/dto/request/CreateDeckBody.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
-public record DeckCreateRequest(
+public record CreateDeckBody(
     @NotNull @Size(min = 3, max = 50) String name, @NotNull List<CardDTO> cards) {
   public record CardDTO(@NotNull String cardId, @Min(1) int quantity, @Min(1) int pos) {}
 }

--- a/src/main/java/com/example/stormpaws/web/dto/request/RandomDeckQueryParam.java
+++ b/src/main/java/com/example/stormpaws/web/dto/request/RandomDeckQueryParam.java
@@ -1,0 +1,10 @@
+package com.example.stormpaws.web.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public record RandomDeckQueryParam(@Min(1) @Max(10) Integer count) {
+  public int resolvedCount() {
+    return count == null ? 10 : count;
+  }
+}

--- a/src/main/java/com/example/stormpaws/web/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/stormpaws/web/exception/GlobalExceptionHandler.java
@@ -2,8 +2,13 @@ package com.example.stormpaws.web.exception;
 
 import com.example.stormpaws.service.exception.OAuthException;
 import com.example.stormpaws.web.dto.response.ApiResponse;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -20,5 +25,18 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiResponse<?>> handleIllegalArgument(IllegalArgumentException ex) {
     return ResponseEntity.badRequest() // 400
         .body(new ApiResponse<>(false, ex.getMessage(), null));
+  }
+
+  @ExceptionHandler({MethodArgumentNotValidException.class, BindException.class})
+  public ResponseEntity<ApiResponse<Map<String, String>>> handleValidationExceptions(Exception ex) {
+    BindingResult result =
+        ex instanceof MethodArgumentNotValidException
+            ? ((MethodArgumentNotValidException) ex).getBindingResult()
+            : ((BindException) ex).getBindingResult();
+
+    Map<String, String> errors = new LinkedHashMap<>();
+    result.getFieldErrors().forEach(err -> errors.put(err.getField(), err.getDefaultMessage()));
+
+    return ResponseEntity.badRequest().body(new ApiResponse<>(false, "Validation failed", errors));
   }
 }

--- a/util/rest_client/deck/GET fetch random deck.http
+++ b/util/rest_client/deck/GET fetch random deck.http
@@ -1,3 +1,3 @@
-GET {{stormpaw-host}}/decks/random-opponents?count=10
+GET {{stormpaw-host}}/decks/random?count=10
 Content-Type: application/json
 Authorization: Bearer {{stormpaw-jwt}}


### PR DESCRIPTION
### 추가사항

-  `GET {{stormpaw-host}}/decks/random?count=n` 랜덤으로 상대방 덱 n개 가져오기 api 생성
-  상대방이 없으면 비어있는채로 반환, n명 이하의 유저이면 있는 유저 수만큼 가져옴.
-  랜덤으로 n명을 선택후 n명의 덱중 랜덤으로 1개를 선택