### PR TITLE
refactor: 메소드별 authentication 진행

### DIFF
--- a/src/main/java/com/example/stormpaws/infra/security/SecurityConfig.java
+++ b/src/main/java/com/example/stormpaws/infra/security/SecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -13,6 +14,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@EnableMethodSecurity
 public class SecurityConfig {
 
   private final CustomUserDetailsService customUserDetailsService;
@@ -41,6 +43,7 @@ public class SecurityConfig {
     http.csrf(csrf -> csrf.disable())
         .sessionManagement(
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .anonymous(anony -> anony.disable())
         .authorizeHttpRequests(auth -> auth.requestMatchers("/**").permitAll())
         .addFilterBefore(
             new JwtAuthenticationFilter(jwtTokenProvider, customUserDetailsService),

--- a/src/main/java/com/example/stormpaws/web/controller/DeckController.java
+++ b/src/main/java/com/example/stormpaws/web/controller/DeckController.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -33,6 +34,7 @@ public class DeckController {
     this.deckService = deckService;
   }
 
+  @PreAuthorize("isAuthenticated()")
   @GetMapping("/decks/{deckId}")
   public ResponseEntity<ApiResponse<DeckModel>> getDeckByID(@PathVariable String deckId) {
     DeckModel deck = deckService.getDeckById(deckId);
@@ -40,6 +42,7 @@ public class DeckController {
     return ResponseEntity.ok(response);
   }
 
+  @PreAuthorize("isAuthenticated()")
   @GetMapping("/user/me/decks")
   public ResponseEntity<ApiResponse<PagedResultDTO<DeckModel>>> getMyDecks(
       @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -51,6 +54,7 @@ public class DeckController {
     return ResponseEntity.ok(response);
   }
 
+  @PreAuthorize("isAuthenticated()")
   @PostMapping("/user/me/decks")
   public ResponseEntity<ApiResponse<DeckModel>> createDeck(
       @Valid @RequestBody CreateDeckBody requestDTO,
@@ -64,6 +68,7 @@ public class DeckController {
   }
 
   // TODO 전역 advice로 처리히기
+  @PreAuthorize("isAuthenticated()")
   @GetMapping("/decks/random")
   public ResponseEntity<ApiResponse<PagedResultDTO<DeckModel>>> getRandomDecks(
       @Valid @ModelAttribute RandomDeckQueryParam param,

--- a/src/main/java/com/example/stormpaws/web/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/stormpaws/web/exception/GlobalExceptionHandler.java
@@ -6,6 +6,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -38,5 +40,21 @@ public class GlobalExceptionHandler {
     result.getFieldErrors().forEach(err -> errors.put(err.getField(), err.getDefaultMessage()));
 
     return ResponseEntity.badRequest().body(new ApiResponse<>(false, "Validation failed", errors));
+  }
+
+  /**
+   * @PreAuthorize 표현식 평가에 실패했을 때 던져지는 예외 (인증된 사용자만 접근 가능할 때, 인증은 했으나 권한이 없으면)
+   */
+  @ExceptionHandler(AccessDeniedException.class)
+  public ResponseEntity<ApiResponse<?>> handleAccessDenied(AccessDeniedException ex) {
+    return ResponseEntity.status(HttpStatus.FORBIDDEN) // 403
+        .body(new ApiResponse<>(false, "Access is denied", null));
+  }
+
+  /** 인증 토큰이 없거나(또는 잘못된 토큰) 인증 처리에 실패했을 때 발생 */
+  @ExceptionHandler(AuthenticationException.class)
+  public ResponseEntity<ApiResponse<?>> handleAuthenticationException(AuthenticationException ex) {
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED) // 401
+        .body(new ApiResponse<>(false, "Authentication required", null));
   }
 }


### PR DESCRIPTION
### 추가내용

- 유저인증이 필요한 엔드포인트의 경우 `@PreAuthorize("isAuthenticated()")` 를 컨트롤러에 넣어주면 잡아주도록 변경

ex)
```
  @PreAuthorize("isAuthenticated()")
  @GetMapping("/user/me/decks")
  public ResponseEntity<ApiResponse<PagedResultDTO<DeckModel>>> getMyDecks(
      @AuthenticationPrincipal CustomUserDetails userDetails,
      @RequestParam(defaultValue = "1") int page,
      @RequestParam(defaultValue = "10") int size) {
    String userId = userDetails.getUser().getId();
    PagedResultDTO<DeckModel> result = deckService.getMyDeckList(userId, page, size);
    ApiResponse<PagedResultDTO<DeckModel>> response = new ApiResponse<>(true, "success", result);
    return ResponseEntity.ok(response);
  }

```
